### PR TITLE
Remove useless PostgreSQL flags

### DIFF
--- a/cookbooks/postgresql/definitions/postgresql_database.rb
+++ b/cookbooks/postgresql/definitions/postgresql_database.rb
@@ -15,7 +15,7 @@ define :postgresql_database, {
 
     execute "create user #{config[:username]}" do
       user node.postgresql.user
-      command "psql --command \"CREATE USER \\\"#{config[:username]}\\\" WITH NOCREATEDB NOCREATEUSER NOCREATEROLE PASSWORD '#{config[:password]}';\""
+      command "psql --command \"CREATE USER \\\"#{config[:username]}\\\" WITH PASSWORD '#{config[:password]}';\""
       not_if "sudo -u #{node.postgresql.user} psql --command=\"select usename from pg_catalog.pg_user where usename=\'#{config[:username]}\';\" --tuples-only | grep #{config[:username]}"
     end
 

--- a/cookbooks/postgresql/recipes/server.rb
+++ b/cookbooks/postgresql/recipes/server.rb
@@ -22,6 +22,7 @@ end
 Chef::Config.exception_handlers << ServiceErrorHandler.new(node.postgresql.service_name, ".*postgresql.*")
 
 directory "/etc/postgresql/#{node.postgresql.version}/main/conf.d" do
+  recursive true
   owner node.postgresql.user
   group node.postgresql.user
 end
@@ -56,7 +57,7 @@ EOF
 
   execute "change postgresql root password" do
     user node.postgresql.user
-    command "psql --command \"CREATE USER #{node.postgresql.root_account} WITH CREATEDB NOCREATEUSER NOCREATEROLE PASSWORD '#{root_postgresql_password}';\""
+    command "psql --command \"CREATE USER #{node.postgresql.root_account} WITH CREATEDB PASSWORD '#{root_postgresql_password}';\""
     not_if "PGPASSWORD=#{root_postgresql_password} psql postgres --username=#{node.postgresql.root_account} --command=\"select 1;\""
   end
 


### PR DESCRIPTION
For 9.4 it's useless.
For 9.6 it's deprecated and removed (so it's necessary to shut it out of here).
A bug is fixed too for idempotence.