### PR TITLE
feat: Use HTTP1.1 instead of HTTP1.0 on nginx proxy

### DIFF
--- a/cookbooks/nginx/attributes/default.rb
+++ b/cookbooks/nginx/attributes/default.rb
@@ -36,6 +36,7 @@ default[:nginx][:config] = {
   :log_formats => {
     :main => "'$remote_addr - $host - [$time_local] ' '\"$request\" $status $body_bytes_sent $request_time \"$http_referer\" ' '\"$http_user_agent\"'"
   },
+  :proxy_http_version => '1.1',
 }
 
 default[:nginx][:package_name] = "nginx"

--- a/cookbooks/nginx/templates/default/nginx.conf.erb
+++ b/cookbooks/nginx/templates/default/nginx.conf.erb
@@ -20,6 +20,8 @@ http {
   tcp_nopush on;
   tcp_nodelay on;
 
+  proxy_http_version <%= node.nginx[:config][:proxy_http_version] %>;
+
 <% if node.nginx[:config][:proxy_buffer_size] %>
   proxy_buffer_size <%= node.nginx[:config][:proxy_buffer_size] %>;
 <% end %>


### PR DESCRIPTION
Pour régler les problèmes de mise en cache des requêtes APHP, je propose de configurer le module proxy de Nginx à HTTP 1.1 par défaut pour tous les services.

Lien vers la documentation Nginx : http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_http_version