### PR TITLE
feat: Check if process is running before sending signal

### DIFF
--- a/cookbooks/nodejs/definitions/nodejs_app.rb
+++ b/cookbooks/nodejs/definitions/nodejs_app.rb
@@ -35,7 +35,7 @@ define :nodejs_app, {
 
       logrotate_file "nodejs_log_file_#{nodejs_app_params[:name]}" do
         files (["#{nodejs_app_params[:name]}.log"] + nodejs_app_params[:logrotate_files]).map{|x| "#{directory}/shared/log/#{x}"}
-        variables :post_rotate => "kill -USR2 `cat #{directory}/shared/#{nodejs_app_params[:name]}.pid`", :user => nodejs_app_params[:user]
+        variables :post_rotate => "pgrep -F #{directory}/shared/#{nodejs_app_params[:name]}.pid > /dev/null && pkill -USR2 -F #{directory}/shared/#{nodejs_app_params[:name]}.pid || /bin/true", :user => nodejs_app_params[:user]
       end
 
     end


### PR DESCRIPTION
En l'état si le process n'est pas en cours d'execution la commande **post_rotate** échoue et génère une erreur lors du passage de la CRON de logrotate.

Cette PR ajoute une vérification sur l'état du process avant d'envoyer un signal.